### PR TITLE
Add method to read sensor instance asynchronously and add option to disable background polling of sensor instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Set any gpio pin to use as W1 data channel (required root permissions).
 ### W1Temp.getSensorsUids()
 Return Promise which returns list of available sensors uids, catch if fails.
 
-### W1Temp.getSensor(*sensorUid*)
+### W1Temp.getSensor(*sensorUid*, *enablePolling* _= true_)
 Return Promise which returns sensor instance, catch if fails.
+The *enablePolling* argument controls whether the sensor will emit *change* events by monitoring the sensor value in the background. Defaults to enabled.
 
 ### &lt;sensor_instance&gt;.getTemperature()
 Returns actual temperature on sensor.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Return Promise which returns sensor instance, catch if fails.
 ### &lt;sensor_instance&gt;.getTemperature()
 Returns actual temperature on sensor.
 
+### &lt;sensor_instance&gt;.getTemperatureAsync()
+Return Promise which returns temperature on sensor.
+
 ### &lt;sensor_instance&gt;.on('change', *callback(temp)*)
 Event on change temperature.
 

--- a/src/lib/Sensor.js
+++ b/src/lib/Sensor.js
@@ -33,6 +33,29 @@ class Sensor extends EventEmitter {
     return false;
   }
 
+  getTemperatureAsync() {
+    return new Promise((resolve, reject) => {
+      fs.readFile(this.file, 'utf8', (err, data) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        const match = data.match(/t=(-?\d+)/);
+
+        if (!match) {
+          reject(new Error('Unable to parse sensor data'));
+          return;
+        }
+        if (data.indexOf('YES') === -1) {
+          reject(new Error('CRC mismatch'));
+          return;
+        }
+        const temp = parseInt(match[1], 10) / 1000;
+        resolve(temp);
+      });
+    });
+  }
+
 }
 
 export default Sensor;

--- a/src/lib/Sensor.js
+++ b/src/lib/Sensor.js
@@ -3,20 +3,22 @@ import { EventEmitter } from 'events';
 
 class Sensor extends EventEmitter {
 
-  constructor(file) {
+  constructor(file, enablePolling = true) {
     super();
 
     this.file = file;
     this.lastTemp = false;
 
-    setInterval(() => {
-      const newTemp = this.getTemperature();
+    if (enablePolling) {
+      setInterval(() => {
+        const newTemp = this.getTemperature();
 
-      if (this.lastTemp !== newTemp) {
-        this.lastTemp = newTemp;
-        this.emit('change', newTemp);
-      }
-    }, 250);
+        if (this.lastTemp !== newTemp) {
+          this.lastTemp = newTemp;
+          this.emit('change', newTemp);
+        }
+      }, 250);
+    }
   }
 
   getTemperature() {

--- a/src/lib/getSensor.js
+++ b/src/lib/getSensor.js
@@ -2,7 +2,7 @@ import fileExistsWait from './fileExistsWait';
 import Sensor from './Sensor';
 import { SENSOR_UID_REGEXP } from './constants';
 
-export default function getSensor(sensorUid) {
+export default function getSensor(sensorUid, enablePolling = true) {
   return new Promise((resolve, reject) => {
     if (!SENSOR_UID_REGEXP.test(sensorUid)) {
       reject(new Error('Bad sensor uid format'));
@@ -11,7 +11,7 @@ export default function getSensor(sensorUid) {
 
       fileExistsWait(file)
         .then(() => {
-          const sensor = new Sensor(file);
+          const sensor = new Sensor(file, enablePolling);
           resolve(sensor);
         })
         .catch(() => {


### PR DESCRIPTION
When monitoring for temperature changes is not required, the background polling every 250ms can be quite an overhead, particularly with synchronous I/O and if multiple sensors are in use.

These changes allow for non-blocking I/O to be used to read temperature values if desired. It also provides a mechanism for controlling whether or not a sensor instance will poll in the background, polling defaults to enabled to preserve API compatibility.