### PR TITLE
Additional command line argument to operate multiple 1wire buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Turn on any gpio pin as W1 power.
 ### W1Temp.setGpioData(*gpioPinNumber*)
 Set any gpio pin to use as W1 data channel (required root permissions).
 
-### W1Temp.getSensorsUids()
+### W1Temp.getSensorsUids(*master_bus_id* = 1)
 Return Promise which returns list of available sensors uids, catch if fails.
+If you operate multiple 1wire buses on one host, *master_bus_id* defines the 1wire bus to use.
 
 ### W1Temp.getSensor(*sensorUid*, *enablePolling* _= true_)
 Return Promise which returns sensor instance, catch if fails.

--- a/src/lib/getSensorsUids.js
+++ b/src/lib/getSensorsUids.js
@@ -2,9 +2,13 @@ import fs from 'fs';
 import fileExistsWait from './fileExistsWait';
 import { SENSOR_UID_REGEXP } from './constants';
 
-export default function getSensorsUids() {
+export default function getSensorsUids(master_bus_id) {
+  if (typeof master_bus_id != "number") {
+    master_bus_id = 1;
+  }
   return new Promise((resolve, reject) => {
-    const file = '/sys/bus/w1/devices/w1_bus_master1/w1_master_slaves';
+    const file = '/sys/bus/w1/devices/w1_bus_master' +
+      master_bus_id + '/w1_master_slaves';
 
     fileExistsWait(file)
       .then(() => {


### PR DESCRIPTION
At the moment only the first 1wire bus is supported by the `getSensorsUids` function.

This pull request adds an additional command line argument to this function to define which bus to use.