### PR TITLE
Change default getTemperature usage to its async equivalent

### DIFF
--- a/src/lib/Sensor.js
+++ b/src/lib/Sensor.js
@@ -11,14 +11,12 @@ class Sensor extends EventEmitter {
     this.onlyIfChanged = onlyIfChanged;
 
     if (enablePolling) {
-      setInterval(() => {
-        const newTemp = this.getTemperature();
-
+      setInterval(() => this.getTemperatureAsync().catch(() => false).then(newTemp => {
         if (!this.onlyIfChanged || this.lastTemp !== newTemp) {
           this.lastTemp = newTemp;
           this.emit('change', newTemp);
         }
-      }, interval);
+      }), interval);
     }
   }
 
@@ -28,8 +26,7 @@ class Sensor extends EventEmitter {
       const match = data.match(/t=(-?\d+)/);
 
       if (data.indexOf('YES') !== -1 && match) {
-        const temp = parseInt(match[1], 10) / 1000;
-        return temp;
+        return parseInt(match[1], 10) / 1000;
       }
     } catch (err) {}
 
@@ -53,8 +50,7 @@ class Sensor extends EventEmitter {
           reject(new Error('CRC mismatch'));
           return;
         }
-        const temp = parseInt(match[1], 10) / 1000;
-        resolve(temp);
+        resolve(parseInt(match[1], 10) / 1000);
       });
     });
   }


### PR DESCRIPTION
The problem solved by this pull request has been noticed by @robertkeizer in #7 but I just used async equivalent of getTemperature function in this interval - current solution doesn't block event loop.